### PR TITLE
Reset warp lock after first motion

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -176,6 +176,7 @@ void event_handle_motion(void) {
      * segments in the meantime. If so, we ignore this. */
     if (has_warped) {
         DLOG("Pointer has already been warped, not warping it again.");
+        has_warped = false;
         return;
     }
 


### PR DESCRIPTION
Reset `has_warp` to false (after it has been set after a successful
warp) when the next motion is received.

This should still prevent the cursor "looping" when warping, while
preventing the cursor from getting "stuck" in torus mode.

fixes #35
