### PR TITLE
build: Add -fcommon for GCC 10 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ MANDIR = $(PREFIX)/share/man/man1
 
 CC = gcc
 CFLAGS += -I$(IDIR)
-CFLAGS += -std=gnu99
+CFLAGS += -std=gnu99 -fcommon
 CFLAGS += -Wall -Wundef -Wshadow
 LIBS = $(shell pkg-config --libs xcb xcb-randr xcb-aux x11 x11-xcb xi)
 


### PR DESCRIPTION
GCC 10 defaults to -fno-common, which rejects multiple definitions of
global variables, resulting in this for outputs_head:

    /usr/sbin/ld: obj/extensions.o:(.bss+0x0): multiple definition of `outputs_head'; obj/event.o:(.bss+0x0): first defined here
    /usr/sbin/ld: obj/fake_outputs.o:(.bss+0x0): multiple definition of `outputs_head'; obj/event.o:(.bss+0x0): first defined here
    /usr/sbin/ld: obj/pointer.o:(.bss+0x0): multiple definition of `outputs_head'; obj/event.o:(.bss+0x0): first defined here
    [...and so on...]

Use -fcommon to go back to the previous behaviour.