### PR TITLE
util: bail: Build with -Werror=format-security

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ MANDIR = $(PREFIX)/share/man/man1
 CC = gcc
 CFLAGS += -I$(IDIR)
 CFLAGS += -std=gnu99 -fcommon
-CFLAGS += -Wall -Wundef -Wshadow
+CFLAGS += -Wall -Wundef -Wshadow -Wformat-security
 LIBS = $(shell pkg-config --libs xcb xcb-randr xcb-aux x11 x11-xcb xi)
 
 INCS = $(wildcard $(IDIR)/*.h)

--- a/src/util.c
+++ b/src/util.c
@@ -8,7 +8,7 @@ void bail(char *message) {
     if (connection != NULL)
         xcb_disconnect(connection);
     ELOG("Received error: %s", message);
-    errx(EXIT_FAILURE, message);
+    errx(EXIT_FAILURE, "%s", message);
 }
 
 /*


### PR DESCRIPTION
This flag is enabled in Arch makepkg CFLAGS by default. There are no
real issues since all of the inputs come from static char[] arrays, but
it seems worth making sure it builds with this option.