### PR TITLE
Fix cursor getting stuck at corners with dead borders

### DIFF
--- a/src/pointer.c
+++ b/src/pointer.c
@@ -59,22 +59,42 @@ direction_t pointer_touches_border(position_t pointer) {
     }
 
     /* Otherwise, we need to check if the border segment is "dead", i.e., there is no
-     * directly neighboring output as in such a case we don't need to do anything. */
-    position_t fake_position = pointer;
-    direction_t direction;
-    if (directions & D_LEFT || directions & D_RIGHT) {
-        direction = directions & D_LEFT ? D_LEFT : D_RIGHT;
-        fake_position.x += direction == D_LEFT ? -1 : 1;
-    } else if (directions & D_TOP || directions & D_BOTTOM) {
-        direction = directions & D_TOP ? D_TOP : D_BOTTOM;
-        fake_position.y += direction == D_TOP ? -1 : 1;
-    } else {
-        bail("Congratulations, you found a bug. Please report it!");
-        /* Never reached */
-        return D_NONE;
+     * directly neighboring output as in such a case we don't need to do anything.
+     * At corners multiple borders may be dead; prefer the one with a reachable neighbor. */
+    Output *current_output = randr_get_output_containing(pointer);
+    direction_t candidates[4] = { D_LEFT, D_RIGHT, D_TOP, D_BOTTOM };
+    /* Fallback if no direction has a reachable neighbor. */
+    direction_t fallback_direction = D_NONE;
+
+    for (int i = 0; i < 4; i++) {
+        direction_t dir = candidates[i];
+        if (!(directions & dir))
+            continue;
+
+        /* Step one pixel in this direction to probe what is there. */
+        position_t fake_position = pointer;
+        switch (dir) {
+            case D_LEFT:   fake_position.x--; break;
+            case D_RIGHT:  fake_position.x++; break;
+            case D_TOP:    fake_position.y--; break;
+            case D_BOTTOM: fake_position.y++; break;
+            default: break;
+        }
+
+        /* If the adjacent pixel is inside an output the border is live —
+         * the pointer can cross naturally, so no warp is needed. */
+        if (randr_get_output_containing(fake_position) != NULL)
+            return D_NONE;
+
+        /* Border is dead. Use this direction if it has an output to warp to. */
+        if (randr_next_output_in_direction(current_output, pointer, dir) != NULL)
+            return dir;
+
+        if (fallback_direction == D_NONE)
+            fallback_direction = dir;
     }
 
-    return randr_get_output_containing(fake_position) == NULL ? direction : D_NONE;
+    return fallback_direction;
 }
 
 /*

--- a/test/t/50-corner-dead-borders.t
+++ b/test/t/50-corner-dead-borders.t
@@ -1,0 +1,46 @@
+#!/usr/bin/env perl
+# vim:ts=4:sw=4:expandtab
+
+use Test::More;
+use xewtest;
+
+my $pointer;
+
+###################################################################################################
+# At a corner where two borders are dead, the cursor should warp in whichever direction
+# has a neighboring output, even if it is not the primary direction.
+#
+# Layout:
+# #######
+#
+# +--------+
+# |        |
+# |   1    +------+
+# |        |  2   |
+# +--------+------+-------+
+# |   3    |      4       |
+# +--------+--------------+
+###################################################################################################
+
+run_xedgewarp(outputs => [
+    '256x144+0+0',
+    '192x108+256+36',
+    '256x144+0+144',
+    '256x144+256+144'
+]);
+
+warp_pointer(128, 72);
+
+# Top-right corner of output 4: right border is dead with no neighbor,
+# top border is dead but output 2 is a valid top neighbor.
+# Expects warp to the bottom-right corner of output 2.
+warp_pointer(511, 144);
+$pointer = get_pointer;
+is($pointer->{x}, 447, 'pointer is warped to the neighboring output (x)');
+is($pointer->{y}, 143, 'pointer is warped to the bottom-right of the new output (y)');
+
+exit_xedgewarp;
+
+###################################################################################################
+
+done_testing;


### PR DESCRIPTION

When the cursor reaches a corner where two borders are both dead, `pointer_touches_border` previously hardcoded horizontal directions (left/right) to take priority over vertical ones. If the horizontal border had no warpable neighbor, the function returned that direction anyway and the warp silently failed - leaving the cursor stuck even though a valid neighbor existed in the vertical direction.

https://github.com/Airblader/xedgewarp/blob/e75aca13bfd567eca3e3e4e611fbb71d76a120c7/src/pointer.c#L61-L70

This was reproducible on setups where a wider bottom monitor extends beyond the right edge of a narrower top monitor. The cursor at the top-right corner of the bottom monitor would touch both a dead right border (nothing to the right) and a dead top border (gap above), but only the right direction was ever tried.

**Fix**: iterate all detected dead borders and return the first one that has a reachable neighbor output, falling back to the original behaviour (first dead direction found) if none do.

**Test**: t/50-corner-dead-borders.t covers a four-output layout matching this geometry and asserts the cursor warps upward to the correct neighbor instead of getting stuck.

Closes #50.



