### PR TITLE
ci: Run the test suite on every push and PR

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,7 +20,9 @@ runs:
           asciidoc \
           xmlto \
           libtest-simple-perl \
-          xvfb
+          cpanminus \
+          xvfb \
+          xserver-xephyr
 
     - name: Cache CPAN modules
       uses: actions/cache@v4

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,40 +9,17 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
-          asciidoc \
-          coreutils \
-          cpanminus \
-          gcc \
-          libanyevent-i3-perl \
-          libanyevent-perl \
-          libdata-dump-perl \
-          libextutils-depends-perl \
-          libextutils-pkgconfig-perl \
-          libinline-perl \
-          libipc-run-perl \
-          libmouse-perl \
-          libmousex-nativetraits-perl \
-          libtest-deep-perl \
-          libtest-differences-perl \
-          libtest-exception-perl \
-          libtest-fatal-perl \
-          libtest-simple-perl \
-          libx11-dev \
-          libx11-xcb-dev \
-          libxcb-icccm4-dev \
+          pkg-config \
+          libxcb1-dev \
           libxcb-randr0-dev \
           libxcb-util-dev \
-          libxcb-xinerama0-dev \
-          libxcb1-dev \
+          libx11-dev \
+          libx11-xcb-dev \
           libxi-dev \
-          libxml-parser-perl \
-          libxml-simple-perl \
-          libxml-tokeparser-perl \
-          make \
-          pkg-config \
-          xauth \
-          xcb-proto \
-          xserver-xephyr \
+          libxfixes-dev \
+          asciidoc \
+          xmlto \
+          libtest-simple-perl \
           xvfb
 
     - name: Cache CPAN modules

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -27,7 +27,6 @@ runs:
           libtest-exception-perl \
           libtest-fatal-perl \
           libtest-simple-perl \
-          libtest-use-ok-perl \
           libx11-dev \
           libx11-xcb-dev \
           libxcb-icccm4-dev \

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,6 +11,10 @@ runs:
         sudo apt-get install -y --no-install-recommends \
           pkg-config \
           libxcb1-dev \
+          libxcb-composite0-dev \
+          libxcb-icccm4-dev \
+          libxcb-xinerama0-dev \
+          libxcb-xkb-dev \
           libxcb-randr0-dev \
           libxcb-util-dev \
           libx11-dev \
@@ -19,6 +23,7 @@ runs:
           libxfixes-dev \
           asciidoc \
           xmlto \
+          xauth \
           libtest-simple-perl \
           cpanminus \
           xvfb \

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -26,6 +26,7 @@ runs:
           xauth \
           libtest-simple-perl \
           cpanminus \
+          xcb-proto \
           xvfb \
           xserver-xephyr
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,23 +13,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          libxcb1-dev \
-          libxcb-randr0-dev \
-          libxcb-util-dev \
-          libx11-dev \
-          libx11-xcb-dev \
-          libxi-dev \
-          libxfixes-dev \
-          libxrandr-dev \
-          asciidoc \
-          xmlto
+    - name: Set up environment
+      uses: ./.github/actions/setup
 
     - name: Build
       run: make
 
     - name: Install (smoke test)
       run: make DESTDIR=$PWD/_install install
+
+    - name: Test
+      run: make test


### PR DESCRIPTION
Wire up 'make test' so the Perl-based xedgewarp test suite (under xvfb-run, with Xephyr) actually runs in CI. The Makefile target uses xvfb-run + Xephyr and the suite needs a substantial set of Perl modules plus X11::XCB and IPC::System::Simple from CPAN.

Replace the inline apt-get block with a reference to the existing .github/actions/setup composite action so the CI and release jobs share one dependency list. The composite already installs xvfb, xserver-xephyr, xauth, all the Perl test modules, cpanminus, and caches the two cpanm-installed CPAN modules — so the CI build path gets all of that for free without duplicating the package list.

The previous inline list also pulled in libxfixes-dev, libxrandr-dev, and xmlto, none of which are referenced by the build (LIBS uses xcb/xcb-randr/xcb-aux/x11/x11-xcb/xi from pkg-config, and a2x is called with --no-xmllint -f manpage). They are dropped along with the inline block.